### PR TITLE
Fix rantingmarker invocation

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -153,7 +153,7 @@
 \newcommand{\cvskill}[2]{%
 \textcolor{emphasis}{\textbf{#1}}\hfill
 \foreach \x in {1,...,5}{%
-  \space{\ifnumgreater{\x}{#2}{\color{body!30}}{\color{accent}}\faCircle}}\par%
+  \space{\ifnumgreater{\x}{#2}{\color{body!30}}{\color{accent}}\ratingmarker}}\par%
 }
 
 % Adapted from @Jake's answer at http://tex.stackexchange.com/a/82729/226


### PR DESCRIPTION
Thank you for doing this CV template is really nice. I wanted to use the command ratingmarker to change the circles in the languages section. Although this feature is offered it didn't work, this fixes it.