### PR TITLE
Remove Blank Space in \cvevent Command

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -131,9 +131,10 @@
 \newcommand{\cvevent}[4]{%
   {\large\color{emphasis}#1\par}
   \smallskip
+  \ifstrequal{#2}{}{}{
   \textbf{\color{accent}#2}\par
-  \smallskip
-  {\small\makebox[0.5\linewidth][l]{\faCalendar \hspace{0.5em}#3}%
+  \smallskip}
+  \ifstrequal{#3}{}{}{\small\makebox[0.5\linewidth][l]{\faCalendar\hspace{0.5em}#3}%
   \ifstrequal{#4}{}{}{\makebox[0.5\linewidth][l]{\faMapMarker\hspace{0.5em}#4}}\par}
   \medskip
 }


### PR DESCRIPTION
- Don't display the calendar icon if there is no time period specified.
- Don't display the empty line and \smallskip if there is no company or institution specified.