### PR TITLE
Fix Link Markdown for Tweet Picture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ v1.1.3 (30 April 2017), by LianTze Lim (liantze@gmail.com)
 
 It all started with this:
 
-[<img src="tweet-that-started-this.png" width="500px">]
-(https://twitter.com/Leonduck/status/764281546408923136)
+[<img src="tweet-that-started-this.png" width="500px">](https://twitter.com/Leonduck/status/764281546408923136)
 
 Leonardo was talking about a [résumé of Marissa Mayer that Business Insider put together](http://www.businessinsider.my/a-sample-resume-for-marissa-mayer-2016-7/) using [enhancv.com](https://enhancv.com).
 I _knew_ I had to do something about it. And so AltaCV was born.


### PR DESCRIPTION
The current Markdown displays the the brackets and parentheses for the link. Made changes to fix this.