### PR TITLE
Fixed Overfull of `\cvref`

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -218,7 +218,7 @@
 \newcommand{\cvref}[3]{%
   \smallskip
   \textcolor{emphasis}{\textbf{#1}}\par
-  \begin{description}[font=\color{accent},style=multiline,leftmargin=1.25em]
+  \begin{description}[font=\color{accent},style=multiline,leftmargin=1.35em]
   \item[\normalfont\emailsymbol] #2
   \item[\small\normalfont\mailsymbol] #3
   \end{description}


### PR DESCRIPTION
The 2 symbols `\emailsymbol` and `\mailsymbol` cause these BadBoxes:
```
	Overfull \hbox (1.07pt too wide) in paragraph
	Overfull \hbox (1.5pt too wide) in paragraph
```
We can fix this problem by increasing the left margin