### PR TITLE
Added Docker and Makefile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:bionic
+
+RUN apt-get update -q && \
+    apt-get install -qy build-essential wget libfontconfig1 unzip fontconfig ghostscript git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install TexLive with scheme-basic
+RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; \
+	  mkdir /install-tl-unx; \
+	  tar -xvf install-tl-unx.tar.gz -C /install-tl-unx --strip-components=1; \
+    echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile; \
+    /install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile; \
+    rm -r /install-tl-unx; \
+    rm install-tl-unx.tar.gz
+
+ENV PATH="/usr/local/texlive/2018/bin/x86_64-linux:${PATH}"
+
+### LaTeX packages ###
+RUN tlmgr install collection-latexrecommended
+RUN tlmgr install collection-latexextra
+RUN tlmgr install collection-fontsrecommended
+RUN tlmgr install latexmk
+RUN tlmgr install biblatex
+RUN tlmgr install biber
+RUN tlmgr install logreq
+RUN tlmgr install fontawesome
+RUN tlmgr install academicons
+RUN tlmgr install lato
+#
+# Add here all packages you need
+#
+### end of LaTeX packages ###
+
+RUN adduser dockuser
+USER dockuser
+
+WORKDIR /home/dockuser/shared
+
+CMD make pdf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+#
+# Makefile
+#
+
+
+# Change the file name with yours
+FILE_NAME = sample
+
+
+###### Docker ######
+D_DIR = Docker
+D_IMAGE = dockercv
+D_CONTAINER = dockercv-container
+
+# Current working directory
+PATH_SHARED = $(shell pwd)
+
+FLAGS = --rm -ti
+VOLUME = -v $(PATH_SHARED):/home/dockuser/shared
+D_FLAGS = $(FLAGS) --name $(D_CONTAINER) $(VOLUME)
+
+###### LaTeX ######
+L_DIR = .
+L_SRC = $(FILE_NAME).tex
+
+LATEXMK = latexmk
+L_FLAGS = -pdf -cd -f -interaction=nonstopmode -file-line-error
+
+# Core latex/pdflatex auxiliary files
+AUX1 = *.acv *.aux *.lof *.log *.lot *.fls *.out *.toc *.fmt *.fot *.cb *.cb2 .*.lb
+# Intermediate documents
+AUX2 = *.dvi *.xdv *-converted-to.*
+# Bibliography auxiliary files (bibtex/biblatex/biber)
+AUX3 = *.bbl *.bcf *.blg *-blx.aux *-blx.bib *.run.xml
+# Build tool auxiliary files
+AUX4 = *.fdb_latexmk *.synctex *.synctex(busy) *.synctex.gz *.synctex.gz(busy) *.pdfsync
+# Beamer
+AUX5 = *.nav *.pre *.snm *.vrb
+# Glossaries
+AUX6 = *.acn *.acr *.glg *.glo *.gls *.glsdefs
+# Algorithms
+AUX7 = *.alg *.loa
+# Makeidx
+AUX8 = *.idx *.ilg *.ind *.ist
+AUX_FILES = $(AUX1) $(AUX2) $(AUX3) $(AUX4) $(AUX5) $(AUX6) $(AUX7) $(AUX8)
+
+#############################################
+#############################################
+#############################################
+
+###### Docker ######
+build:
+	docker build -t $(D_IMAGE) $(D_DIR)
+
+run:
+	docker run $(D_FLAGS) $(D_IMAGE)
+
+bash:
+	docker run $(D_FLAGS) $(D_IMAGE) bash
+
+###### LaTeX ######
+pdf:
+	$(LATEXMK) $(L_FLAGS) $(L_DIR)/$(L_SRC)
+
+clean:
+	@rm -f $(foreach file, $(AUX_FILES), $(wildcard $(file)))
+	@echo "Removed all aux files"
+
+clean-all: clean
+	@rm -f *.pdf
+	@echo "Removed all pdf files"

--- a/README.md
+++ b/README.md
@@ -32,3 +32,28 @@ Though if you're creating your own CV/résumé, you'd probably prefer using the 
 * Can now be compiled with pdflatex, XeLaTeX and LuaLaTeX!
 * However if you're using `academicons`, you _must_ use either XeLaTeX or LuaLaTeX. If the doc then compiles but the icons don't show up in the output PDF, try compiling with LuaLaTeX instead.
 * The samples here use the [Lato](http://www.latofonts.com/lato-free-fonts/) font.
+
+
+## Docker & Make
+Change the variable *FILE_NAME* in the Makefile file with your file name. The default name is *sample*.
+
+1. Run the command `make build` to create the docker image. It takes a few minutes.
+
+  Now you have two options.
+
+  2.a. Generate *sample.pdf* by running the command `make run`.
+
+  2.b. Generate *sample.pdf* by running the command `make bash` and then inside the docker container, `make pdf`.
+
+#### Commands
+`$ make build`: build the docker image
+
+`$ make bash`: run the docker container in the terminal
+
+`$ make run`: run the docker container and generate *sample.pdf*
+
+`$ make pdf`: generate *sample.pdf*
+
+`$ make clean`: remove all aux files
+
+`$ make clean-all`: remove all aux and *.pdf* files

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Change the variable *FILE_NAME* in the Makefile file with your file name. The de
 
 1. Run the command `make build` to create the docker image. It takes a few minutes.
 
-  Now you have two options.
+    Now you have two options.
 
-  2.a. Generate *sample.pdf* by running the command `make run`.
+    2.a. Generate *sample.pdf* by running the command `make run`.
 
-  2.b. Generate *sample.pdf* by running the command `make bash` and then inside the docker container, `make pdf`.
+    2.b. Generate *sample.pdf* by running the command `make bash` and then inside the docker container, `make pdf`.
 
 #### Commands
 `$ make build`: build the docker image


### PR DESCRIPTION
I created a Makefile and a Dockerfile.
The Dockerfile builds a Docker with all packages to compile *.pdf* files that use the class **AltaCV**.
The Makefile makes everything easier. You can build the Docker running `make build` and create the *.pdf* running `make run`. 

These are all commands:
`$ make build`: build the docker image
`$ make bash`: run the docker container in the terminal
`$ make run`: run the docker container and generate *sample.pdf*
`$ make pdf`: generate *sample.pdf*
`$ make clean`: remove all aux files
`$ make clean-all`: remove all aux and *.pdf* files