### PR TITLE
Add support for inline lists

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -106,8 +106,8 @@
 \RequirePackage{tikz}
 \usetikzlibrary{arrows}
 \RequirePackage[skins]{tcolorbox}
-\RequirePackage{enumitem}
-\setlist{leftmargin=*,labelsep=0.5em,nosep,itemsep=0.25\baselineskip,after=\vskip0.25\baselineskip}
+\RequirePackage[inline]{enumitem}
+\setlist{leftmargin=*,labelsep=0.5em,nosep,itemsep=0.25\baselineskip,after=\vspace{0.25\baselineskip}}
 \setlist[itemize]{label=\itemmarker}
 \RequirePackage{graphicx}
 \RequirePackage{etoolbox}


### PR DESCRIPTION
Current implementation does not allow for inline lists created with `itemize*` due to `\vskip`. `\vskip` led to an infinite loop when I tried to make an inline list.