### PR TITLE
Improved Profile-link Commands

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -138,15 +138,15 @@
 \newcommand{\name}[1]{\def\@name{#1}}
 \newcommand{\tagline}[1]{\def\@tagline{#1}}
 \newcommand{\photo}[2]{\def\@photo{#2}\def\@photodiameter{#1}}
-\newcommand{\email}[1]{\printinfo{\emailsymbol}{#1}}
+\newcommand{\email}[1]{\printinfo{\emailsymbol}{\href{mailto:#1}{#1}}}
 \newcommand{\mailaddress}[1]{\printinfo{\mailsymbol}{#1}}
 \newcommand{\phone}[1]{\printinfo{\phonesymbol}{#1}}
 \newcommand{\homepage}[1]{\printinfo{\homepagesymbol}{#1}}
 \newcommand{\twitter}[1]{\printinfo{\twittersymbol}{#1}}
-\newcommand{\linkedin}[1]{\printinfo{\linkedinsymbol}{#1}}
-\newcommand{\github}[1]{\printinfo{\githubsymbol}{#1}}
 \newcommand{\orcid}[1]{\printinfo{\orcidsymbol}{#1}}
 \newcommand{\location}[1]{\printinfo{\locationsymbol}{#1}}
+\newcommand{\linkedin}[1]{\printinfo{\linkedinsymbol}{\href{https://linkedin.com/in/#1}{#1}}}
+\newcommand{\github}[1]{\printinfo{\githubsymbol}{\href{https://github.com/#1}{#1}}}
 
 \newcommand{\personalinfo}[1]{\def\@personalinfo{#1}}
 

--- a/altacv.cls
+++ b/altacv.cls
@@ -132,6 +132,8 @@
 \newcommand{\githubsymbol}{\faGithub}
 \newcommand{\orcidsymbol}{\aiOrcid}
 \newcommand{\mailsymbol}{\faEnvelope}
+\newcommand{\scholar}[1]{\printinfo{\faGraduationCap}{\href{https://scholar.google.com/citations?user=#1}{#1}}}
+\newcommand{\xing}[1]{\printinfo{\faXingSquare}{\href{https://www.xing.com/profile/#1}{#1}}}
 
 \newcommand{\printinfo}[2]{\mbox{\textcolor{accent}{\normalfont #1}\hspace{0.5em}#2\hspace{2em}}}
 

--- a/altacv.cls
+++ b/altacv.cls
@@ -144,7 +144,7 @@
 \newcommand{\mailaddress}[1]{\printinfo{\mailsymbol}{#1}}
 \newcommand{\phone}[1]{\printinfo{\phonesymbol}{#1}}
 \newcommand{\homepage}[1]{\printinfo{\homepagesymbol}{#1}}
-\newcommand{\twitter}[1]{\printinfo{\twittersymbol}{#1}}
+\newcommand{\twitter}[1]{\printinfo{\twittersymbol}{\href{https://twitter.com/}{#1}}}
 \newcommand{\orcid}[1]{\printinfo{\orcidsymbol}{#1}}
 \newcommand{\location}[1]{\printinfo{\locationsymbol}{#1}}
 \newcommand{\linkedin}[1]{\printinfo{\linkedinsymbol}{\href{https://linkedin.com/in/#1}{#1}}}

--- a/sample.tex
+++ b/sample.tex
@@ -74,8 +74,8 @@
   \location{Location, COUNTRY}
   \homepage{www.homepage.com/}
   \twitter{@twitterhandle}
-  \linkedin{linkedin.com/in/yourid}
-  \github{github.com/yourid}
+  \linkedin{yourid}
+  \github{yourid}
   %% You MUST add the academicons option to \documentclass, then compile with LuaLaTeX or XeLaTeX, if you want to use \orcid or other academicons commands.
   % \orcid{orcid.org/0000-0000-0000-0000}
 }


### PR DESCRIPTION
Minor changes to the profile-commands that display links to girhib,linkedin etc. in the header:
- text displayed by email, linkedIn and github command is now a clickable hyperlink
- linkedIn and GIthub command now only have to display name of the actual profile, not entire url
        ( 'myprofile' will be displayed instead of 'www.linkedin.com/in/myprofile')
- added two new commands: googlescholar and xing
