### PR TITLE
Change ORCID URL to orcid.org

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -215,7 +215,7 @@
 \NewInfoField{twitter}{\faTwitter}[https://twitter.com/]
 \NewInfoField{linkedin}{\faLinkedin}[https://linkedin.com/in/]
 \NewInfoField{github}{\faGithub}[https://github.com/]
-\NewInfoField{orcid}{\aiOrcid}[https://orcid.com/]
+\NewInfoField{orcid}{\aiOrcid}[https://orcid.org/]
 \NewInfoField{location}{\faMapMarker}
 
 % v1.2: Support for multiple photos


### PR DESCRIPTION
The correct URL for ORCID is `orcid.org` not `orcid.com`. The latter doesn't even exist.