### PR TITLE
Create a github action that compiles the pdf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,6 @@ name: Build pdf
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  schedule:
-  - cron: "0 12 1 * *"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Runs a single command using the runners shell
-      - name: Run a one-line script
+      - name: cd on workspace
         run: cd $GITHUB_WORKSPACE
 
 
@@ -71,12 +71,14 @@ jobs:
           args: ""
           # Install extra packages by apt-get
           # extra_system_packages: # optional
-            
-      - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2.2.0
+                        
+      - name: Rename pdf
+        run: mv sample.pdf cv.pdf
+        
+      - name: Git Release
+        # You may pin to the exact commit or the version.
+        # uses: anton-yurchenko/git-release@fb9b4ce2363c8b8d50fcbc9cddd2b12785a1f25a
+        uses: anton-yurchenko/git-release@v3.4.1
         with:
-          # Artifact name
-          name: cv.pdf # optional, default is artifact
-          # A file, directory or wildcard pattern that describes what to upload
-          path: ./sample.pdf
-          # The desired behavior if no files are found using the provided path.
+          # Release Assets
+          args: cv.pdf # optional

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Build pdf
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v2.2.0
         with:
           # Artifact name
-          name: sample.pdf # optional, default is artifact
+          name: cv.pdf # optional, default is artifact
           # A file, directory or wildcard pattern that describes what to upload
-          path: .
+          path: ./sample.pdf
           # The desired behavior if no files are found using the provided path.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      - name: Github Action for LaTeX
+        # You may pin to the exact commit or the version.
+        # uses: xu-cheng/latex-action@dacf2cfbdd5fd768c2298cbdc9e105bd9ed7f293
+        uses: xu-cheng/latex-action@v2
+        with:
+          # The root LaTeX file to be compiled
+          root_file: sample.tex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
           DRAFT_RELEASE: "false"
           PRE_RELEASE: "false"
           ALLOW_EMPTY_CHANGELOG: "true"
-          ALLOW_TAG_PREFIX: "true"
+          ALLOW_TAG_PREFIX: "false"
         with:
           # Release Assets
           args: cv.pdf # optional

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,9 @@ jobs:
                         
       - name: Rename pdf
         run: mv sample.pdf cv.pdf
+      
+      - name: Create empty changelog
+        run: echo "# Update CV" > CHANGELOG.md
         
       - name: Git Release
         # You may pin to the exact commit or the version.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+  - cron: "0 12 1 * *"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -69,3 +71,12 @@ jobs:
           args: ""
           # Install extra packages by apt-get
           # extra_system_packages: # optional
+            
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.0
+        with:
+          # Artifact name
+          name: sample.pdf # optional, default is artifact
+          # A file, directory or wildcard pattern that describes what to upload
+          path: .
+          # The desired behavior if no files are found using the provided path.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,23 @@ jobs:
         with:
           # The root LaTeX file to be compiled
           root_file: sample.tex
+          compiler: pdflatex
+          
+      - name: Latex Biber Action
+        # You may pin to the exact commit or the version.
+        # uses: julianahrens/latex-biber-action@b030657c4bc77278ee7ec178a6a4339e50c6333b
+        uses: julianahrens/latex-biber-action@v2
+        with:
+          # Filename of .tex file
+          filename: sample.tex
+          # Define build directory
+          output-directory: .
+
+      - name: Github Action for LaTeX
+        # You may pin to the exact commit or the version.
+        # uses: xu-cheng/latex-action@dacf2cfbdd5fd768c2298cbdc9e105bd9ed7f293
+        uses: xu-cheng/latex-action@v2
+        with:
+          # The root LaTeX file to be compiled
+          root_file: sample.tex
+          compiler: pdflatex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,32 +24,48 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run a one-line script
-        run: echo Hello, world!
+        run: cd $GITHUB_WORKSPACE
 
-      - name: Github Action for LaTeX
+
+      - name: LaTeX compilation
         # You may pin to the exact commit or the version.
-        # uses: xu-cheng/latex-action@dacf2cfbdd5fd768c2298cbdc9e105bd9ed7f293
-        uses: xu-cheng/latex-action@v2
+        # uses: dante-ev/latex-action@259e5ff953ad4d4616fbd09cc87a526ee5c4499a
+        uses: dante-ev/latex-action@v0.2.0
         with:
           # The root LaTeX file to be compiled
           root_file: sample.tex
-          compiler: pdflatex
-          
+          # The working directory for the latex compiler to be invoked
+          working_directory: . # optional
+          # LaTeX engine to be used
+          compiler: pdflatex # optional, default is latexmk
+          # Extra arguments to be passed to the latex compiler
+          args: ""
+          # Install extra packages by apt-get
+          # extra_system_packages: # optional
+
+
       - name: Latex Biber Action
         # You may pin to the exact commit or the version.
         # uses: julianahrens/latex-biber-action@b030657c4bc77278ee7ec178a6a4339e50c6333b
         uses: julianahrens/latex-biber-action@v2
         with:
           # Filename of .tex file
-          filename: sample.tex
+          filename: sample
           # Define build directory
           output-directory: .
-
-      - name: Github Action for LaTeX
+          
+      - name: LaTeX compilation
         # You may pin to the exact commit or the version.
-        # uses: xu-cheng/latex-action@dacf2cfbdd5fd768c2298cbdc9e105bd9ed7f293
-        uses: xu-cheng/latex-action@v2
+        # uses: dante-ev/latex-action@259e5ff953ad4d4616fbd09cc87a526ee5c4499a
+        uses: dante-ev/latex-action@v0.2.0
         with:
           # The root LaTeX file to be compiled
           root_file: sample.tex
-          compiler: pdflatex
+          # The working directory for the latex compiler to be invoked
+          working_directory: . # optional
+          # LaTeX engine to be used
+          compiler: pdflatex # optional, default is latexmk
+          # Extra arguments to be passed to the latex compiler
+          args: ""
+          # Install extra packages by apt-get
+          # extra_system_packages: # optional

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,16 +78,24 @@ jobs:
       - name: Create empty changelog
         run: echo "# Update CV" > CHANGELOG.md
         
-      - name: Git Release
+      - name: Update Release
         # You may pin to the exact commit or the version.
-        # uses: anton-yurchenko/git-release@fb9b4ce2363c8b8d50fcbc9cddd2b12785a1f25a
-        uses: anton-yurchenko/git-release@v3.4.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRAFT_RELEASE: "false"
-          PRE_RELEASE: "false"
-          ALLOW_EMPTY_CHANGELOG: "true"
-          ALLOW_TAG_PREFIX: "false"
+        # uses: johnwbyrd/update-release@1d5ec4791e40507e5eca3b4dbf90f0b27e7e4979
+        uses: johnwbyrd/update-release@v1.0.0
         with:
-          # Release Assets
-          args: cv.pdf # optional
+          # Your Github token; try \$\{\{ secrets.GITHUB_TOKEN \}\} if your build lasts less than an hour, or create your own secret token with repository access if your build requires longer than an hour.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Paths to built files to be released. May be absolute or relative to \$\{\{ github.workspace \}\}.
+          files: cv.pdf
+          # The name of the release to be created. A reasonable looking release name will be created from the current \$\{\{ github.ref \}\} if this input is not supplied.
+          # release: # optional
+          # The name of the tag to be used. If not provided, the name of the release will be used.
+          tag: "latest" # optional
+          # A one-line description for both the tag and the release.
+          message: "Update CS" # optional
+          # A fuller description of the release.
+          #body: # optional
+          # Should the release, if created, be marked as a prerelease?  Such releases are generally publicly visible.
+          # prerelease: # optional, default is true
+          # Should the release, if created, be marked as a draft?  Such releases are generally not publicly visible.
+          # draft: # optional

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,48 +25,22 @@ jobs:
         run: cd $GITHUB_WORKSPACE
 
 
-      - name: LaTeX compilation
+      - name: Github Action for LaTeX
         # You may pin to the exact commit or the version.
         # uses: dante-ev/latex-action@259e5ff953ad4d4616fbd09cc87a526ee5c4499a
-        uses: dante-ev/latex-action@v0.2.0
+        uses: xu-cheng/latex-action@v2
         with:
           # The root LaTeX file to be compiled
           root_file: sample.tex
           # The working directory for the latex compiler to be invoked
           working_directory: . # optional
           # LaTeX engine to be used
-          compiler: pdflatex # optional, default is latexmk
+          # compiler: pdflatex # optional, default is latexmk
           # Extra arguments to be passed to the latex compiler
-          args: ""
+          # args: ""
           # Install extra packages by apt-get
           # extra_system_packages: # optional
 
-
-      - name: Latex Biber Action
-        # You may pin to the exact commit or the version.
-        # uses: julianahrens/latex-biber-action@b030657c4bc77278ee7ec178a6a4339e50c6333b
-        uses: julianahrens/latex-biber-action@v2
-        with:
-          # Filename of .tex file
-          filename: sample
-          # Define build directory
-          output-directory: .
-          
-      - name: LaTeX compilation
-        # You may pin to the exact commit or the version.
-        # uses: dante-ev/latex-action@259e5ff953ad4d4616fbd09cc87a526ee5c4499a
-        uses: dante-ev/latex-action@v0.2.0
-        with:
-          # The root LaTeX file to be compiled
-          root_file: sample.tex
-          # The working directory for the latex compiler to be invoked
-          working_directory: . # optional
-          # LaTeX engine to be used
-          compiler: pdflatex # optional, default is latexmk
-          # Extra arguments to be passed to the latex compiler
-          args: ""
-          # Install extra packages by apt-get
-          # extra_system_packages: # optional
                         
       - name: Rename pdf
         run: mv sample.pdf cv.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,12 @@ jobs:
         # You may pin to the exact commit or the version.
         # uses: anton-yurchenko/git-release@fb9b4ce2363c8b8d50fcbc9cddd2b12785a1f25a
         uses: anton-yurchenko/git-release@v3.4.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRAFT_RELEASE: "false"
+          PRE_RELEASE: "false"
+          ALLOW_EMPTY_CHANGELOG: "true"
+          ALLOW_TAG_PREFIX: "true"
         with:
           # Release Assets
           args: cv.pdf # optional

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+
+sample.synctex.gz
+
+sample.aux
+
+pdfa.xmpi
+
+sample.bcf
+
+sample.out
+
+sample.run.xml

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ sample.bcf
 sample.out
 
 sample.run.xml
+
+sample.bbl
+
+sample.blg

--- a/altacv.cls
+++ b/altacv.cls
@@ -38,6 +38,7 @@
 %% v1.3.2 Hopefully this helps make the PDF
 %% file more 'friendly' with copy-paste etc
 \RequirePackage[a-1b]{pdfx}
+\catcode30=12
 \RequirePackage[margin=2cm]{geometry}
 \RequirePackage[fixed]{fontawesome5}
 \RequirePackage{ifxetex,ifluatex}


### PR DESCRIPTION
These modifications add Github actions that compile and publish as release the last version of sample.tex as a file named "cv.pdf".
It is thus possible to get the last version of the generated pdf at the URL: https://github.com/:owner/AltaCV/releases/download/latest/cv.pdf