### PR TITLE
Allow customization of bibliography style

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -396,7 +396,7 @@
 
 \newenvironment{cvcolumn}[1]{\begin{minipage}[t]{#1}\raggedright}{\end{minipage}}
 
-\RequirePackage[backend=biber,style=authoryear,sorting=ydnt]{biblatex}
+\RequirePackage[backend=biber,sorting=ydnt]{biblatex}
 %% For removing numbering entirely when using a numeric style
 % \setlength{\bibhang}{1em}
 % \DeclareFieldFormat{labelnumberwidth}{\makebox[\bibhang][l]{\itemmarker}}

--- a/sample.tex
+++ b/sample.tex
@@ -11,6 +11,9 @@
 %% version 2003/12/01 or later.
 %%%%%%%%%%%%%%%%
 
+%% Set the bibliography style
+\PassOptionsToPackage{style=authoryear}{biblatex}
+
 %% If you are using \orcid or academicons
 %% icons, make sure you have the academicons
 %% option here, and compile with XeLaTeX


### PR DESCRIPTION
Resolves #71 by removing the `style=authoryear` directive from altacv.cls, and adding a line to the sample document customizing the bibliography style by using the `PassOptionsToPackage` command. Since the bibliography style is now set in the document instead of the class, it can be customized without needing to edit the class itself.