### PR TITLE
backward compatibility

### DIFF
--- a/legacy/sample-old.tex
+++ b/legacy/sample-old.tex
@@ -34,7 +34,7 @@
 
 % Change the font if you want to, depending on whether
 % you're using pdflatex or xelatex/lualatex
-\ifxetexorluatex
+\ifxetex
   % If using xelatex or lualatex:
   \setmainfont{Roboto Slab}
   \setsansfont{Lato}

--- a/mmayer.tex
+++ b/mmayer.tex
@@ -30,7 +30,7 @@
 % you're using pdflatex or xelatex/lualatex
 % WHEN COMPILING WITH XELATEX PLEASE USE
 % xelatex -shell-escape -output-driver="xdvipdfmx -z 0" mmayer.tex
-\ifxetexorluatex
+\ifxetex
   % If using xelatex or lualatex:
   \setmainfont{Lato}
 \else

--- a/sample.tex
+++ b/sample.tex
@@ -28,7 +28,7 @@
 % you're using pdflatex or xelatex/lualatex
 % WHEN COMPILING WITH XELATEX PLEASE USE
 % xelatex -shell-escape -output-driver="xdvipdfmx -z 0" sample.tex
-\ifxetexorluatex
+\ifxetex
   % If using xelatex or lualatex:
   \setmainfont{Roboto Slab}
   \setsansfont{Lato}


### PR DESCRIPTION
no more support for `\ifxetexorluatex` - replace to `\ifxetex` in examples