### PR TITLE
Fix horizontal mode `nointerlineskip` bug

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -304,7 +304,7 @@
 \renewenvironment{quote}{\color{accent}\itshape\large}{\par}
 
 \newcommand{\cvsection}[2][]{%
-  \nointerlineskip\bigskip%  %% bugfix in v1.6.2
+  \par\nointerlineskip\bigskip%  %% horizontal mode (par) bugfix in v1.7.3
   \ifstrequal{#1}{}{}{\marginpar{\vspace*{\dimexpr1pt-\baselineskip}\raggedright\input{#1}}}%
   {\color{heading}\cvsectionfont\MakeUppercase{#2}}\\[-1ex]%
   {\color{headingrule}\rule{\linewidth}{2pt}\par}\medskip


### PR DESCRIPTION
* Fixes an error triggered by calling `\nointerlineskip` in horizontal mode.
* This error only appeared for me when locally upgrading my Emacs version to 29.4.4 (which I use to convert `org` files to `tex` files).