### PR TITLE
use `luatex85` to avoid `pdfx` using pdf 1.4 with lualatex

### DIFF
--- a/altacv.cls
+++ b/altacv.cls
@@ -42,6 +42,7 @@
 \RequirePackage{xcolor}
 %% v1.3.2 Hopefully this helps make the PDF
 %% file more 'friendly' with copy-paste etc
+\RequirePackage{luatex85}
 \RequirePackage[a-1b]{pdfx}
 \RequirePackage{accsupp}
 %% v1.7.3 Avoid 'Token not allowed' when \\ used with accsupp


### PR DESCRIPTION
This should allow using the latest pdf v1.7

Without this, `pdfx` will force using pdf 1.4 in lualatex.